### PR TITLE
Handle missing image preview for non-persisted models in file field

### DIFF
--- a/spec/views/chobble_forms/_file_field.html.erb_spec.rb
+++ b/spec/views/chobble_forms/_file_field.html.erb_spec.rb
@@ -43,6 +43,29 @@ RSpec.describe "chobble_forms/_file_field.html.erb", type: :view do
     end
   end
 
+  context "when file is attached but model is not persisted" do
+    let(:attachment) { double("attachment") }
+    let(:blob) { double("blob") }
+
+    before do
+      allow(attachment).to receive(:attached?).and_return(true)
+      allow(attachment).to receive(:blob).and_return(blob)
+      allow(attachment).to receive(:filename).and_return("test.jpg")
+      allow(attachment).to receive(:image?).and_return(true)
+      allow(mock_object).to receive(:respond_to?).with(:photo).and_return(true)
+      allow(mock_object).to receive(:photo).and_return(attachment)
+      allow(mock_object).to receive(:persisted?).and_return(false)
+    end
+
+    it "does not render preview for new records" do
+      render "chobble_forms/file_field", field: field
+
+      expect(rendered).to have_text("Photo")
+      expect(rendered).to have_selector('input[type="file"][name="photo"]')
+      expect(rendered).not_to have_selector(".file-preview")
+    end
+  end
+
   context "when file is attached" do
     let(:attachment) { double("attachment") }
     let(:blob) { double("blob") }
@@ -62,6 +85,7 @@ RSpec.describe "chobble_forms/_file_field.html.erb", type: :view do
       allow(service).to receive(:exist?).and_return(true)
       allow(mock_object).to receive(:respond_to?).with(:photo).and_return(true)
       allow(mock_object).to receive(:photo).and_return(attachment)
+      allow(mock_object).to receive(:persisted?).and_return(true)
     end
 
     context "with image file and preview enabled" do

--- a/views/chobble_forms/_file_field.html.erb
+++ b/views/chobble_forms/_file_field.html.erb
@@ -12,7 +12,7 @@
 <%= setup[:form_object].label field, setup[:field_label] %>
 <%= setup[:form_object].file_field field, accept: accept %>
 
-<% if current_file&.attached? %>
+<% if current_file&.attached? && model.persisted? %>
   <div class="file-preview" style="margin-top: 10px;">
     <% if current_file.image? %>
       <%= image_tag current_file.variant(resize_to_limit: [preview_size, preview_size]),


### PR DESCRIPTION
## Summary
- Prevents rendering of image preview when the file is attached but the model is not persisted
- Ensures file preview only shows for persisted records to avoid errors or misleading UI

## Changes

### View Template
- Updated `_file_field.html.erb` to conditionally render the file preview only if the model is persisted and the file is attached

### Tests
- Added new RSpec context in `_file_field.html.erb_spec.rb` to cover scenario where file is attached but model is new (not persisted)
- Verified that preview is not rendered for new records while file input and label are still present

## Test plan
- [x] Confirm file preview is not shown for new records with attached files
- [x] Confirm file preview is shown for persisted records with attached files
- [x] Verify existing file input and label rendering remains unchanged

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6af6c16a-03a3-4f46-a091-8ae569f6fa2c