### PR TITLE
Migrate form CSS to modular stylesheets and update asset pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
 # Chobble Forms
 
 Semantic Rails forms with strict i18n enforcement.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'chobble-forms'
+```
+
+And then execute:
+
+```bash
+bundle install
+```
+
+## CSS Styles
+
+ChobbleForms includes CSS for styling the form components. To use the included styles, add this to your application.css:
+
+```css
+/*
+ *= require chobble_forms
+ */
+```
+
+The CSS includes:
+
+- **Form Grids**: Responsive grid layouts for various form field combinations
+- **Form Fields**: Styling for inputs, textareas, and labels
+- **Radio Buttons**: Custom radio button appearance with pass/fail color coding
+- **Flash Messages**: Styled success, error, notice, and alert messages
+
+### CSS Variables
+
+The CSS uses the following CSS variables that you can override in your application:
+
+- `--color-primary`: Primary color for hover states (default: #118bee)
+- `--color-pass`: Pass/success color (default: #00a94f)
+- `--color-fail`: Fail/error color (default: #d32f2f)
+- `--color-disabled`: Disabled state color (default: #959495)

--- a/app/assets/stylesheets/chobble_forms.css
+++ b/app/assets/stylesheets/chobble_forms.css
@@ -1,0 +1,9 @@
+/*
+ * ChobbleForms CSS Manifest
+ * This file includes all the CSS components for the ChobbleForms gem
+ *
+ *= require chobble_forms/form_grids
+ *= require chobble_forms/form_fields
+ *= require chobble_forms/radio_buttons
+ *= require chobble_forms/flash_messages
+ */

--- a/app/assets/stylesheets/chobble_forms/flash_messages.css
+++ b/app/assets/stylesheets/chobble_forms/flash_messages.css
@@ -1,0 +1,73 @@
+/* Flash Messages
+ * Styles for success, error, notice, and alert messages
+ */
+
+.success,
+.error,
+.notice,
+.alert {
+	width: 30rem;
+	max-width: 90%;
+	margin: 2rem auto;
+	text-align: left;
+	padding: 1rem;
+	border-radius: 8px;
+	font-weight: 500;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+	animation: fadeIn 0.5s ease-in;
+}
+
+.success {
+	background: linear-gradient(135deg, #e8f5e8 0%, #f0fff0 100%);
+	border: 1px solid #90ee90;
+	color: #2d5016;
+}
+
+.notice {
+	background: linear-gradient(135deg, #e8f8ff 0%, #b6f5ff 100%);
+	border: 1px solid #b8e4ff;
+	color: #505f84;
+}
+
+.error {
+	background: linear-gradient(135deg, #ffe8e8 0%, #fff0f0 100%);
+	border: 1px solid #ffb3b3;
+	color: #cc0000;
+}
+
+.alert {
+	background: linear-gradient(135deg, #fff3cd 0%, #fffae5 100%);
+	border: 1px solid #ffd700;
+	color: #856404;
+}
+
+.error ul {
+	margin: 0.5rem 0 0 0;
+	padding: 0;
+	list-style: none;
+}
+
+.error li {
+	margin: 0.25rem 0;
+	padding-left: 1rem;
+	position: relative;
+}
+
+.error li:before {
+	content: "•";
+	position: absolute;
+	left: 0;
+	color: #cc0000;
+	font-weight: bold;
+}
+
+@keyframes fadeIn {
+	from {
+		opacity: 0;
+		transform: translateY(-10px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}

--- a/app/assets/stylesheets/chobble_forms/form_fields.css
+++ b/app/assets/stylesheets/chobble_forms/form_fields.css
@@ -1,0 +1,126 @@
+/* Form Field Styling
+ * Styles for form inputs, textareas, and related elements within form grids
+ */
+
+/* Highlight animation for targeted form elements */
+form *:target {
+	animation: highlight-fade 5s ease-out forwards;
+	border-radius: 5px;
+}
+
+@keyframes highlight-fade {
+	0% {
+		background: #ffff3766;
+		outline: 20px solid #ffff3766;
+	}
+	80% {
+		background: #ffff3766;
+		outline: 20px solid #ffff3766;
+	}
+	100% {
+		background: transparent;
+		outline: 20px solid transparent;
+	}
+}
+
+/* Form grid field styling */
+.form-grid input,
+.form-grid label {
+	margin: 0;
+	padding: 0;
+}
+
+.form-grid input[type="text"],
+.form-grid input[type="number"] {
+	padding: 0.4rem 0.8rem;
+}
+
+.form-grid input[type="number"],
+.form-grid input[type="text"][inputmode="decimal"] {
+	width: 5rem;
+	text-align: left;
+	padding: 0.4rem;
+	font-variant-numeric: tabular-nums;
+}
+
+.form-grid textarea {
+	margin: 0 0 0.5rem;
+	padding: 0.5rem 1rem;
+}
+
+.form-grid label {
+	display: flex;
+	flex-direction: row;
+	gap: 0.5rem;
+}
+
+.form-grid .label {
+	line-height: 1.1rem;
+	text-wrap: balance;
+}
+
+.form-grid .pass-fail {
+	display: flex;
+	gap: 0.5rem;
+}
+
+.form-grid .pass-fail label {
+	display: flex;
+}
+
+.form-grid input[type="radio"] {
+	/* Prevent the radio from affecting grid layout */
+	vertical-align: middle;
+}
+
+/* Comment field container */
+.comment-field-container {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.comment-field-container label {
+	cursor: pointer;
+	font-weight: normal;
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.comment-field-container input[type="checkbox"] {
+	margin: 0;
+}
+
+/* Field with link styling */
+.field.field-with-link {
+	position: relative;
+}
+
+.field.field-with-link a {
+	position: absolute;
+	right: 10px;
+	top: 35px;
+	font-size: 0.9em;
+}
+
+/* Muted state for N/A toggled fields */
+.muted {
+	opacity: 0.4;
+}
+
+/* Form actions (submit button + secondary link) */
+.form-actions {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 1rem;
+	flex-wrap: wrap;
+}
+
+/* Secondary button styling */
+.secondary[role="button"],
+a.secondary[role="button"] {
+	background: var(--color-bg);
+	color: var(--color-link);
+}

--- a/app/assets/stylesheets/chobble_forms/form_grids.css
+++ b/app/assets/stylesheets/chobble_forms/form_grids.css
@@ -1,0 +1,208 @@
+/* Form Grid Layouts
+ * Provides flexible grid layouts for various form field combinations
+ */
+
+.form-grid {
+	display: grid;
+	gap: 1rem;
+	align-items: end;
+	padding-top: 1rem;
+}
+
+legend + .form-grid {
+	border-top: none;
+}
+
+/* Radio + Comment grid layout */
+.radio-comment {
+	grid-template-areas:
+		"label label"
+		"pass-fail comment-label"
+		"comment comment";
+	grid-template-columns: auto 1fr;
+	align-items: center;
+}
+
+@media (min-width: 768px) {
+	.radio-comment {
+		grid-template-areas:
+			"label pass-fail comment-space comment-label"
+			"comment comment comment comment";
+		grid-template-columns: max-content auto 1fr auto;
+	}
+}
+
+.radio-comment > .label {
+	grid-area: label;
+}
+
+.radio-comment > .label label {
+	flex-direction: column;
+}
+
+.radio-comment > .pass-fail {
+	grid-area: pass-fail;
+}
+
+.radio-comment > .comment-checkbox {
+	grid-area: comment-label;
+}
+
+.radio-comment > textarea {
+	grid-area: comment;
+}
+
+/* Number + Pass/Fail + Comment grid layout */
+.number-radio-comment {
+	grid-template-areas:
+		"label label"
+		"number pass-fail"
+		"comment-label comment-space"
+		"comment comment";
+	grid-template-columns: auto 1fr;
+}
+
+@media (min-width: 768px) {
+	.number-radio-comment {
+		grid-template-areas:
+			"label label label label"
+			"number pass-fail comment-space comment-label"
+			"comment comment comment comment";
+		grid-template-columns: auto auto 1fr auto;
+	}
+}
+
+.number-radio-comment > .label {
+	grid-area: label;
+}
+
+.number-radio-comment > .label label {
+	flex-direction: column;
+}
+
+.number-radio-comment > .number {
+	grid-area: number;
+}
+
+.number-radio-comment > .pass-fail {
+	grid-area: pass-fail;
+}
+
+.number-radio-comment > .comment-checkbox {
+	grid-area: comment-label;
+}
+
+.number-radio-comment > textarea {
+	grid-area: comment;
+}
+
+/* Number + Comment grid layout */
+.number-comment {
+	grid-template-areas:
+		"label label"
+		"number comment-label"
+		"comment comment";
+	grid-template-columns: min-content auto;
+	align-items: center;
+}
+
+@media (min-width: 768px) {
+	.number-comment {
+		grid-template-areas:
+			"label number comment-space comment-label"
+			"comment comment comment comment";
+		grid-template-columns: max-content 6rem 1fr auto;
+	}
+}
+
+.number-comment > .label {
+	grid-area: label;
+	width: 14rem;
+}
+
+.number-comment > .number {
+	grid-area: number;
+}
+
+.number-comment > .comment-checkbox {
+	grid-area: comment-label;
+}
+
+.number-comment > textarea {
+	grid-area: comment;
+}
+
+/* Checkbox + Comment grid layout */
+.checkbox-comment {
+	display: grid;
+	gap: 0.5rem;
+	align-items: center;
+	margin-bottom: 1rem;
+	grid-template-areas:
+		"label label label label"
+		"check1 label2 comment-space comment-label";
+	grid-template-columns: auto auto 1fr auto;
+}
+
+@media (min-width: 768px) {
+	.checkbox-comment {
+		grid-template-areas: "label check1 label2 comment-label";
+		grid-template-columns: max-content auto auto auto;
+	}
+}
+
+.checkbox-comment > .label {
+	grid-area: label;
+}
+
+.checkbox-comment > .checkbox {
+	grid-area: check1;
+}
+
+.checkbox-comment > .checkbox-label {
+	grid-area: label2;
+}
+
+.checkbox-comment > .comment-checkbox {
+	grid-area: comment-label;
+}
+
+.checkbox-comment > textarea {
+	grid-column: 1 / -1;
+	margin-top: 0.5rem;
+}
+
+/* Simple number layout */
+.number {
+	grid-template-area: "label number";
+	grid-template-columns: auto min-content;
+	align-items: center;
+}
+
+.number-comment > .label {
+	grid-area: label;
+}
+
+.number-comment > .number {
+	grid-area: number;
+	width: 14rem;
+}
+
+/* User capacity flexbox layout */
+fieldset#user_capacity {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 1rem;
+}
+
+/* Mobile: 2 columns (2 rows of 2) */
+fieldset#user_capacity > * {
+	flex: 1 1 calc(50% - 0.5rem);
+}
+
+/* Desktop: 4 columns (1 row of 4) */
+@media (min-width: 768px) {
+	fieldset#user_capacity > * {
+		flex: 1 1 calc(25% - 0.75rem);
+	}
+}

--- a/app/assets/stylesheets/chobble_forms/radio_buttons.css
+++ b/app/assets/stylesheets/chobble_forms/radio_buttons.css
@@ -1,0 +1,116 @@
+/* Custom Radio Button Styles
+ * Modern, accessible radio button styling with pass/fail color coding
+ * Based on https://moderncss.dev/pure-css-custom-styled-radio-buttons/
+ */
+
+input[type="radio"] {
+	/* Remove default appearance */
+	-webkit-appearance: none;
+	appearance: none;
+	/* For iOS < 15 */
+	background-color: transparent;
+	/* Not removed via appearance */
+	margin: 0;
+
+	/* Custom styling */
+	font: inherit;
+	color: currentColor;
+	width: 1.15em;
+	height: 1.15em;
+	border: 0.15em solid currentColor;
+	border-radius: 50%;
+	transform: translateY(-0.075em);
+
+	/* Create the dot in the center */
+	display: inline-grid;
+	place-content: center;
+
+	/* Ensure the radio is clickable */
+	cursor: pointer;
+	
+	/* Smooth transitions */
+	transition: border-color 120ms ease-in-out;
+}
+
+input[type="radio"]::before {
+	content: "";
+	width: 0.65em;
+	height: 0.65em;
+	border-radius: 50%;
+	transform: scale(0);
+	transition: 120ms transform ease-in-out;
+	/* Use currentColor for IE fallback */
+	background-color: currentColor;
+}
+
+input[type="radio"]:checked::before {
+	transform: scale(1);
+}
+
+input[type="radio"]:focus {
+	outline: max(2px, 0.15em) solid currentColor;
+	outline-offset: max(2px, 0.15em);
+}
+
+input[type="radio"]:disabled {
+	color: var(--color-disabled, #959495);
+	cursor: not-allowed;
+}
+
+/* Label styling for radio buttons */
+label:has(input[type="radio"]) {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5em;
+	cursor: pointer;
+	line-height: 1.1;
+	/* Ensure label remains clickable */
+	position: relative;
+	display: flex;
+}
+
+label > input[type="radio"] {
+	margin-left: 0;
+	margin-right: 0;
+}
+
+/* Pass/Fail color coding */
+.pass-fail input[value="true"]::before,
+.pass-fail input[value="pass"]::before {
+	box-shadow: inset 1em 1em var(--color-pass, #00a94f);
+}
+
+.pass-fail input[value="false"]::before,
+.pass-fail input[value="fail"]::before {
+	box-shadow: inset 1em 1em var(--color-fail, #d32f2f);
+}
+
+/* Hover state */
+label:hover input[type="radio"]:not(:disabled) {
+	border-color: var(--color-primary, #118bee);
+}
+
+/* High contrast support */
+@media (prefers-contrast: high) {
+	input[type="radio"] {
+		border-width: 0.2em;
+	}
+
+	input[type="radio"]:checked::before {
+		background-color: CanvasText;
+		box-shadow: none;
+	}
+}
+
+/* Print styles */
+@media print {
+	input[type="radio"]:checked {
+		border-width: 0.1em;
+		background-color: black;
+	}
+
+	input[type="radio"]:checked::before {
+		background-color: black;
+		box-shadow: none;
+	}
+}

--- a/chobble-forms.gemspec
+++ b/chobble-forms.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
 
-  spec.files = Dir["{lib,views}/**/*", "README.md", "LICENSE", "CHANGELOG.md"]
+  spec.files = Dir["{app,lib,views}/**/*", "README.md", "LICENSE", "CHANGELOG.md"]
 
   spec.add_dependency "rails", ">= 7.0.0"
 

--- a/lib/chobble_forms/engine.rb
+++ b/lib/chobble_forms/engine.rb
@@ -20,8 +20,10 @@ module ChobbleForms
 
     # Asset pipeline configuration
     initializer "chobble_forms.assets" do |app|
-      app.config.assets.paths << root.join("app/assets/stylesheets")
-      app.config.assets.precompile += %w[chobble_forms.css]
+      if app.config.respond_to?(:assets) && app.config.assets
+        app.config.assets.paths << root.join("app/assets/stylesheets")
+        app.config.assets.precompile += %w[chobble_forms.css]
+      end
     end
   end
 end

--- a/lib/chobble_forms/engine.rb
+++ b/lib/chobble_forms/engine.rb
@@ -19,10 +19,9 @@ module ChobbleForms
     end
 
     # Asset pipeline configuration
-    initializer "chobble_forms.assets.precompile" do |app|
+    initializer "chobble_forms.assets" do |app|
+      app.config.assets.paths << root.join("app/assets/stylesheets")
       app.config.assets.precompile += %w[chobble_forms.css]
     end
-
-    config.assets.paths << File.expand_path("../../app/assets/stylesheets", __dir__)
   end
 end

--- a/lib/chobble_forms/engine.rb
+++ b/lib/chobble_forms/engine.rb
@@ -17,5 +17,12 @@ module ChobbleForms
         include ChobbleForms::Helpers
       end
     end
+
+    # Asset pipeline configuration
+    initializer "chobble_forms.assets.precompile" do |app|
+      app.config.assets.precompile += %w[chobble_forms.css]
+    end
+
+    config.assets.paths << File.expand_path("../../app/assets/stylesheets", __dir__)
   end
 end


### PR DESCRIPTION
## Summary
- Migrates all form-related CSS into modular, component-specific stylesheets
- Adds new CSS files for form grids, form fields, radio buttons, and flash messages
- Introduces a CSS manifest file to include all form styles
- Updates the asset pipeline to precompile the new CSS manifest
- Enhances README with installation instructions and CSS usage details
- Updates gemspec to include app assets in packaged files

## Changes

### CSS Structure
- Created `chobble_forms.css` as a manifest to require all form-related CSS components
- Added `form_grids.css` for responsive grid layouts of form fields
- Added `form_fields.css` for styling inputs, textareas, labels, and form actions
- Added `radio_buttons.css` for custom styled radio buttons with pass/fail color coding
- Added `flash_messages.css` for styled success, error, notice, and alert messages

### Asset Pipeline
- Configured engine to precompile `chobble_forms.css`
- Added stylesheet path to asset pipeline

### Documentation
- Expanded README with installation steps and instructions on including CSS
- Documented CSS variables for easy customization of colors

### Packaging
- Updated gemspec to include `app/assets` files in gem packaging

## Test plan
- Verified CSS files are loaded correctly in a Rails app
- Confirmed styles apply as expected for form grids, fields, radio buttons, and flash messages
- Tested asset precompilation includes the new CSS manifest
- Checked README instructions for clarity and correctness

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7c3880a0-2d1f-4fc1-bf34-0cc9e3c58f9d