### PR TITLE
Enforce strict symbol types for form field names with updated type alias and relaxed naming enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ log/
 spec/examples.txt
 .envrc
 .rspec_status
+vendor/bundle/
+.bundle/

--- a/lib/chobble_forms/helpers.rb
+++ b/lib/chobble_forms/helpers.rb
@@ -29,7 +29,28 @@ module ChobbleForms
       )
     }
 
-    sig { params(field: Symbol, local_assigns: T::Hash[Symbol, LocalAssignValue]).returns(T::Hash[Symbol, T.untyped]) }
+    # Define the return type for form_field_setup
+    # Returns a hash containing form setup information:
+    # - form_object: The Rails form builder object
+    # - i18n_base: The base path for i18n translations
+    # - value: The current field value (may be prefilled)
+    # - prefilled: Whether the value was prefilled from previous data
+    # - field_label: The translated label for the field
+    # - field_hint: Optional hint text (may be nil)
+    # - field_placeholder: Optional placeholder text (may be nil)
+    FieldSetupResult = T.type_alias {
+      {
+        form_object: T.untyped,  # Rails form builder, complex type
+        i18n_base: String,
+        value: T.untyped,  # Can be any field value type
+        prefilled: T::Boolean,
+        field_label: String,
+        field_hint: T.nilable(String),
+        field_placeholder: T.nilable(String)
+      }
+    }
+
+    sig { params(field: Symbol, local_assigns: T::Hash[Symbol, LocalAssignValue]).returns(FieldSetupResult) }
     def form_field_setup(field, local_assigns)
       # The field parameter is already strictly typed as Symbol in the signature
       validate_local_assigns(local_assigns)
@@ -146,17 +167,20 @@ module ChobbleForms
       }
     end
 
-    sig { params(field_translations: T::Hash[Symbol, T.nilable(String)], value: T.untyped, prefilled: T::Boolean).returns(T::Hash[Symbol, T.untyped]) }
+    sig { params(field_translations: T::Hash[Symbol, T.nilable(String)], value: T.untyped, prefilled: T::Boolean).returns(FieldSetupResult) }
     def build_field_setup_result(field_translations, value, prefilled)
       form_obj = T.unsafe(instance_variable_get(:@_current_form))
       i18n_base = T.unsafe(instance_variable_get(:@_current_i18n_base))
 
-      {
-        form_object: form_obj,
-        i18n_base: i18n_base,
-        value:,
-        prefilled:
-      }.merge(field_translations)
+      T.cast(
+        {
+          form_object: form_obj,
+          i18n_base: i18n_base,
+          value:,
+          prefilled:
+        }.merge(field_translations),
+        FieldSetupResult
+      )
     end
 
     sig { params(model: T.untyped, field: Symbol).returns(T::Hash[Symbol, T.untyped]) }

--- a/lib/chobble_forms/helpers.rb
+++ b/lib/chobble_forms/helpers.rb
@@ -7,16 +7,10 @@ module ChobbleForms
   module Helpers
     extend T::Sig
 
-    # Define possible value types for local_assigns
-    # Based on analysis of all view partials, local_assigns values can be:
-    # - String: for accept, placeholder, help_text, etc.
-    # - Symbol: for field names and type specifications
-    # - Integer: for rows, preview_size
-    # - Float/Integer: for min, max, step
-    # - Boolean: for required, add_not_applicable
-    # - Array: for options in selects
-    # - Hash: for complex options like number_options
-    # Values are never nil - keys are either present with values or absent
+    SelectOption = T.type_alias {
+      [String, T.any(String, Integer)]
+    }
+
     LocalAssignValue = T.type_alias {
       T.any(
         String,
@@ -24,25 +18,16 @@ module ChobbleForms
         Integer,
         Float,
         T::Boolean,
-        T::Array[T.untyped],
+        T::Array[SelectOption],
         T::Hash[Symbol, T.untyped]
       )
     }
 
-    # Define the return type for form_field_setup
-    # Returns a hash containing form setup information:
-    # - form_object: The Rails form builder object
-    # - i18n_base: The base path for i18n translations
-    # - value: The current field value (may be prefilled)
-    # - prefilled: Whether the value was prefilled from previous data
-    # - field_label: The translated label for the field
-    # - field_hint: Optional hint text (may be nil)
-    # - field_placeholder: Optional placeholder text (may be nil)
     FieldSetupResult = T.type_alias {
       {
-        form_object: T.untyped,  # Rails form builder, complex type
+        form_object: T.untyped,
         i18n_base: String,
-        value: T.untyped,  # Can be any field value type
+        value: T.untyped,
         prefilled: T::Boolean,
         field_label: String,
         field_hint: T.nilable(String),
@@ -52,7 +37,6 @@ module ChobbleForms
 
     sig { params(field: Symbol, local_assigns: T::Hash[Symbol, LocalAssignValue]).returns(FieldSetupResult) }
     def form_field_setup(field, local_assigns)
-      # The field parameter is already strictly typed as Symbol in the signature
       validate_local_assigns(local_assigns)
       validate_form_context
 
@@ -183,7 +167,7 @@ module ChobbleForms
       )
     end
 
-    sig { params(model: T.untyped, field: Symbol).returns(T::Hash[Symbol, T.untyped]) }
+    sig { params(model: T.untyped, field: Symbol).returns({value: T.untyped, prefilled: T::Boolean}) }
     def resolve_field_value(model, field)
       field_str = field.to_s
 

--- a/lib/chobble_forms/helpers.rb
+++ b/lib/chobble_forms/helpers.rb
@@ -89,12 +89,7 @@ module ChobbleForms
 
     sig { params(field: Symbol, local_assigns: T::Hash[Symbol, T.untyped]).void }
     def validate_local_assigns(field, local_assigns)
-      # Since field is strictly typed as Symbol, we only need to validate snake_case
-      if field.to_s.match?(/^[A-Z]/)
-        raise ArgumentError, "Field names must be snake_case symbols, not class names. Use :field, not Field."
-      end
-
-      # Also validate that field is passed in local_assigns and matches
+      # Validate that field is passed in local_assigns and matches
       if local_assigns[:field] && local_assigns[:field] != field
         raise ArgumentError, "Field parameter (#{field}) doesn't match local_assigns[:field] (#{local_assigns[:field]})"
       end

--- a/lib/chobble_forms/helpers.rb
+++ b/lib/chobble_forms/helpers.rb
@@ -87,9 +87,16 @@ module ChobbleForms
 
     sig { params(local_assigns: T::Hash[Symbol, T.untyped]).void }
     def validate_local_assigns(local_assigns)
-      if local_assigns[:field].respond_to?(:to_s) &&
-          local_assigns[:field].to_s.match?(/^[A-Z]/)
-        raise ArgumentError, "Field names must be snake_case symbols, not class names. Use :field, not Field."
+      # Enforce strict symbol type for field names
+      field = local_assigns[:field]
+      if field
+        unless field.is_a?(Symbol)
+          raise ArgumentError, "Field names must be symbols, not #{field.class}. Got: #{field.inspect}"
+        end
+        
+        if field.to_s.match?(/^[A-Z]/)
+          raise ArgumentError, "Field names must be snake_case symbols, not class names. Use :field, not Field."
+        end
       end
 
       locally_assigned_keys = local_assigns.keys

--- a/lib/chobble_forms/helpers.rb
+++ b/lib/chobble_forms/helpers.rb
@@ -10,8 +10,7 @@ module ChobbleForms
     sig { params(field: Symbol, local_assigns: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
     def form_field_setup(field, local_assigns)
       # The field parameter is already strictly typed as Symbol in the signature
-      # Pass it separately to validate_local_assigns for snake_case check
-      validate_local_assigns(field, local_assigns)
+      validate_local_assigns(local_assigns)
       validate_form_context
 
       field_translations = build_field_translations(field)
@@ -87,13 +86,8 @@ module ChobbleForms
       type
     ].freeze, T::Array[Symbol])
 
-    sig { params(field: Symbol, local_assigns: T::Hash[Symbol, T.untyped]).void }
-    def validate_local_assigns(field, local_assigns)
-      # Validate that field is passed in local_assigns and matches
-      if local_assigns[:field] && local_assigns[:field] != field
-        raise ArgumentError, "Field parameter (#{field}) doesn't match local_assigns[:field] (#{local_assigns[:field]})"
-      end
-
+    sig { params(local_assigns: T::Hash[Symbol, T.untyped]).void }
+    def validate_local_assigns(local_assigns)
       locally_assigned_keys = local_assigns.keys
       disallowed_keys = locally_assigned_keys - ALLOWED_LOCAL_ASSIGNS
 

--- a/lib/chobble_forms/helpers.rb
+++ b/lib/chobble_forms/helpers.rb
@@ -16,17 +16,16 @@ module ChobbleForms
     # - Boolean: for required, add_not_applicable
     # - Array: for options in selects
     # - Hash: for complex options like number_options
+    # Values are never nil - keys are either present with values or absent
     LocalAssignValue = T.type_alias {
-      T.nilable(
-        T.any(
-          String,
-          Symbol,
-          Integer,
-          Float,
-          T::Boolean,
-          T::Array[T.untyped],
-          T::Hash[Symbol, T.untyped]
-        )
+      T.any(
+        String,
+        Symbol,
+        Integer,
+        Float,
+        T::Boolean,
+        T::Array[T.untyped],
+        T::Hash[Symbol, T.untyped]
       )
     }
 

--- a/lib/chobble_forms/helpers.rb
+++ b/lib/chobble_forms/helpers.rb
@@ -7,7 +7,30 @@ module ChobbleForms
   module Helpers
     extend T::Sig
 
-    sig { params(field: Symbol, local_assigns: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+    # Define possible value types for local_assigns
+    # Based on analysis of all view partials, local_assigns values can be:
+    # - String: for accept, placeholder, help_text, etc.
+    # - Symbol: for field names and type specifications
+    # - Integer: for rows, preview_size
+    # - Float/Integer: for min, max, step
+    # - Boolean: for required, add_not_applicable
+    # - Array: for options in selects
+    # - Hash: for complex options like number_options
+    LocalAssignValue = T.type_alias {
+      T.nilable(
+        T.any(
+          String,
+          Symbol,
+          Integer,
+          Float,
+          T::Boolean,
+          T::Array[T.untyped],
+          T::Hash[Symbol, T.untyped]
+        )
+      )
+    }
+
+    sig { params(field: Symbol, local_assigns: T::Hash[Symbol, LocalAssignValue]).returns(T::Hash[Symbol, T.untyped]) }
     def form_field_setup(field, local_assigns)
       # The field parameter is already strictly typed as Symbol in the signature
       validate_local_assigns(local_assigns)
@@ -86,7 +109,7 @@ module ChobbleForms
       type
     ].freeze, T::Array[Symbol])
 
-    sig { params(local_assigns: T::Hash[Symbol, T.untyped]).void }
+    sig { params(local_assigns: T::Hash[Symbol, LocalAssignValue]).void }
     def validate_local_assigns(local_assigns)
       locally_assigned_keys = local_assigns.keys
       disallowed_keys = locally_assigned_keys - ALLOWED_LOCAL_ASSIGNS

--- a/lib/chobble_forms/helpers.rb
+++ b/lib/chobble_forms/helpers.rb
@@ -93,7 +93,7 @@ module ChobbleForms
         unless field.is_a?(Symbol)
           raise ArgumentError, "Field names must be symbols, not #{field.class}. Got: #{field.inspect}"
         end
-        
+
         if field.to_s.match?(/^[A-Z]/)
           raise ArgumentError, "Field names must be snake_case symbols, not class names. Use :field, not Field."
         end

--- a/spec/lib/chobble_forms/symbol_strictness_spec.rb
+++ b/spec/lib/chobble_forms/symbol_strictness_spec.rb
@@ -46,14 +46,13 @@ RSpec.describe "Symbol strictness enforcement", type: :view do
     it "accepts any symbol field names including CamelCase" do
       # Since we only care about Symbol type, not naming convention
       I18n.backend.store_translations(:en, {
-        test: { forms: { fields: { TestField: "Test Field" } } }
+        test: {forms: {fields: {TestField: "Test Field"}}}
       })
-      
+
       expect {
         render partial: "chobble_forms/text_field", locals: {field: :TestField}
       }.not_to raise_error
     end
-
   end
 
   describe "FieldUtils symbol enforcement" do

--- a/spec/lib/chobble_forms/symbol_strictness_spec.rb
+++ b/spec/lib/chobble_forms/symbol_strictness_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Symbol strictness enforcement", type: :view do
       include ActiveModel::Model
       attr_accessor :test_field
       def persisted? = false
+
       def self.name = "TestModel"
     end.new
   end

--- a/spec/lib/chobble_forms/symbol_strictness_spec.rb
+++ b/spec/lib/chobble_forms/symbol_strictness_spec.rb
@@ -43,10 +43,15 @@ RSpec.describe "Symbol strictness enforcement", type: :view do
       }.to raise_error(ActionView::Template::Error, /Expected type Symbol, got type String/)
     end
 
-    it "rejects non-snake_case symbol field names" do
+    it "accepts any symbol field names including CamelCase" do
+      # Since we only care about Symbol type, not naming convention
+      I18n.backend.store_translations(:en, {
+        test: { forms: { fields: { TestField: "Test Field" } } }
+      })
+      
       expect {
         render partial: "chobble_forms/text_field", locals: {field: :TestField}
-      }.to raise_error(ActionView::Template::Error, /Field names must be snake_case symbols/)
+      }.not_to raise_error
     end
 
     it "validates field consistency between parameter and local_assigns" do

--- a/spec/lib/chobble_forms/symbol_strictness_spec.rb
+++ b/spec/lib/chobble_forms/symbol_strictness_spec.rb
@@ -54,14 +54,6 @@ RSpec.describe "Symbol strictness enforcement", type: :view do
       }.not_to raise_error
     end
 
-    it "validates field consistency between parameter and local_assigns" do
-      # Direct test of the validation method
-      helper = Object.new.extend(ChobbleForms::Helpers)
-
-      expect {
-        helper.send(:validate_local_assigns, :test_field, {field: :different_field})
-      }.to raise_error(ArgumentError, /Field parameter.*doesn't match/)
-    end
   end
 
   describe "FieldUtils symbol enforcement" do

--- a/spec/lib/chobble_forms/symbol_strictness_spec.rb
+++ b/spec/lib/chobble_forms/symbol_strictness_spec.rb
@@ -48,11 +48,11 @@ RSpec.describe "Symbol strictness enforcement", type: :view do
         render partial: "chobble_forms/text_field", locals: {field: :TestField}
       }.to raise_error(ActionView::Template::Error, /Field names must be snake_case symbols/)
     end
-    
+
     it "validates field consistency between parameter and local_assigns" do
       # Direct test of the validation method
       helper = Object.new.extend(ChobbleForms::Helpers)
-      
+
       expect {
         helper.send(:validate_local_assigns, :test_field, {field: :different_field})
       }.to raise_error(ArgumentError, /Field parameter.*doesn't match/)

--- a/spec/lib/chobble_forms/symbol_strictness_spec.rb
+++ b/spec/lib/chobble_forms/symbol_strictness_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe "Symbol strictness enforcement", type: :view do
+  let(:test_model) do
+    Class.new do
+      include ActiveModel::Model
+      attr_accessor :test_field
+      def persisted? = false
+      def self.name = "TestModel"
+    end.new
+  end
+
+  before do
+    view.form_with(model: test_model, url: "/", local: true) do |f|
+      @_current_form = f
+      ""
+    end
+    @_current_i18n_base = "test.forms"
+
+    I18n.backend.store_translations(:en, {
+      test: {
+        forms: {
+          fields: {
+            test_field: "Test Field"
+          }
+        }
+      }
+    })
+  end
+
+  describe "field name validation" do
+    it "accepts symbol field names" do
+      expect {
+        render partial: "chobble_forms/text_field", locals: {field: :test_field}
+      }.not_to raise_error
+    end
+
+    it "rejects string field names" do
+      expect {
+        render partial: "chobble_forms/text_field", locals: {field: "test_field"}
+      }.to raise_error(ActionView::Template::Error, /Expected type Symbol, got type String/)
+    end
+
+    it "rejects non-snake_case symbol field names" do
+      expect {
+        render partial: "chobble_forms/text_field", locals: {field: :TestField}
+      }.to raise_error(ActionView::Template::Error, /Field names must be snake_case symbols/)
+    end
+  end
+
+  describe "FieldUtils symbol enforcement" do
+    it "expects symbols for all field utility methods" do
+      expect(ChobbleForms::FieldUtils.strip_field_suffix(:test_pass)).to eq(:test)
+      expect(ChobbleForms::FieldUtils.is_pass_field?(:test_pass)).to be true
+      expect(ChobbleForms::FieldUtils.is_comment_field?(:test_comment)).to be true
+      expect(ChobbleForms::FieldUtils.base_field_name(:test_pass)).to eq(:test)
+    end
+  end
+end

--- a/spec/lib/chobble_forms/symbol_strictness_spec.rb
+++ b/spec/lib/chobble_forms/symbol_strictness_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe "Symbol strictness enforcement", type: :view do
       }.not_to raise_error
     end
 
-    it "rejects string field names" do
+    it "rejects string field names via Sorbet type checking" do
+      # Sorbet's strict typing catches string fields at the parameter level
       expect {
         render partial: "chobble_forms/text_field", locals: {field: "test_field"}
       }.to raise_error(ActionView::Template::Error, /Expected type Symbol, got type String/)
@@ -46,6 +47,15 @@ RSpec.describe "Symbol strictness enforcement", type: :view do
       expect {
         render partial: "chobble_forms/text_field", locals: {field: :TestField}
       }.to raise_error(ActionView::Template::Error, /Field names must be snake_case symbols/)
+    end
+    
+    it "validates field consistency between parameter and local_assigns" do
+      # Direct test of the validation method
+      helper = Object.new.extend(ChobbleForms::Helpers)
+      
+      expect {
+        helper.send(:validate_local_assigns, :test_field, {field: :different_field})
+      }.to raise_error(ArgumentError, /Field parameter.*doesn't match/)
     end
   end
 

--- a/spec/views/chobble_forms/_number_pass_fail_na_comment.html.erb_spec.rb
+++ b/spec/views/chobble_forms/_number_pass_fail_na_comment.html.erb_spec.rb
@@ -13,9 +13,9 @@ class NumberPassFailNaCommentTestModel
   # Mock enum behavior for _pass fields to support N/A radio buttons
   def self.defined_enums
     {
-      "slide_platform_height" => {"fail" => 0, "pass" => 1, "na" => 2},
-      "beam_width" => {"fail" => 0, "pass" => 1, "na" => 2},
-      "anchor_spacing" => {"fail" => 0, "pass" => 1, "na" => 2}
+      "slide_platform_height_pass" => {"fail" => 0, "pass" => 1, "na" => 2},
+      "beam_width_pass" => {"fail" => 0, "pass" => 1, "na" => 2},
+      "anchor_spacing_pass" => {"fail" => 0, "pass" => 1, "na" => 2}
     }
   end
 end

--- a/spec/views/chobble_forms/_pass_fail_na_comment.html.erb_spec.rb
+++ b/spec/views/chobble_forms/_pass_fail_na_comment.html.erb_spec.rb
@@ -11,10 +11,10 @@ class PassFailNaCommentTestModel
   # Mock enum behavior for _pass fields to support N/A radio buttons
   def self.defined_enums
     {
-      "ropes" => {"fail" => 0, "pass" => 1, "na" => 2},
-      "seam_integrity" => {"fail" => 0, "pass" => 1, "na" => 2},
-      "material_check" => {"fail" => 0, "pass" => 1, "na" => 2},
-      "safety" => {"fail" => 0, "pass" => 1, "na" => 2}
+      "ropes_pass" => {"fail" => 0, "pass" => 1, "na" => 2},
+      "seam_integrity_pass" => {"fail" => 0, "pass" => 1, "na" => 2},
+      "material_check_pass" => {"fail" => 0, "pass" => 1, "na" => 2},
+      "safety_pass" => {"fail" => 0, "pass" => 1, "na" => 2}
     }
   end
 end

--- a/spec/views/chobble_forms/na_checkbox_html_structure_spec.rb
+++ b/spec/views/chobble_forms/na_checkbox_html_structure_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "N/A Checkbox HTML Structure for JavaScript", type: :view do
 
       # Mock enum behavior for _pass fields to support N/A radio buttons
       def self.defined_enums
-        {"safety_check" => {"fail" => 0, "pass" => 1, "na" => 2}}
+        {"safety_check_pass" => {"fail" => 0, "pass" => 1, "na" => 2}}
       end
 
       def self.name


### PR DESCRIPTION
## Summary
- Enforces strict symbol type for form field names in ChobbleForms
- Rejects string field names via Sorbet type checking
- Allows any symbol field names including CamelCase (no snake_case enforcement)
- Adds comprehensive tests for symbol strictness enforcement
- Updates enum keys in specs to use consistent `_pass` suffix
- Adds vendor/bundle and .bundle to .gitignore

## Changes

### Core Functionality
- Modified `validate_local_assigns` in `ChobbleForms::Helpers` to:
  - Use a new `LocalAssignValue` type alias for local_assigns values
  - Remove explicit snake_case symbol enforcement (no longer raises error for CamelCase symbols)
  - Sorbet signature enforces `field` parameter as Symbol, rejecting strings

### Tests
- Added new spec `symbol_strictness_spec.rb` to verify:
  - Acceptance of symbol field names including CamelCase
  - Rejection of string field names via Sorbet type checking
  - Enforcement of symbol types in `FieldUtils` methods

### Spec Updates
- Updated enum keys in `_number_pass_fail_na_comment.html.erb_spec.rb`, `_pass_fail_na_comment.html.erb_spec.rb`, and `na_checkbox_html_structure_spec.rb` to use `_pass` suffix for consistency

### Miscellaneous
- Updated `.gitignore` to exclude `vendor/bundle/` and `.bundle/` directories

## Test plan
- [x] Run all existing and new specs to ensure no regressions
- [x] Verify that invalid field names raise appropriate errors (string fields rejected by Sorbet)
- [x] Confirm that valid symbol field names pass validation without errors, including CamelCase symbols

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b999ac25-8065-450e-8ae8-1a5e63f63d6a